### PR TITLE
#20 - 회원 계정 엔티티와 게시글, 댓글에 연관관계 적용

### DIFF
--- a/src/main/java/com/study/springbootboard/controller/MainController.java
+++ b/src/main/java/com/study/springbootboard/controller/MainController.java
@@ -1,0 +1,13 @@
+package com.study.springbootboard.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class MainController {
+
+    @GetMapping("/")
+    public String root() {
+        return "redirect:/articles";
+    }
+}

--- a/src/main/java/com/study/springbootboard/domain/type/SearchType.java
+++ b/src/main/java/com/study/springbootboard/domain/type/SearchType.java
@@ -1,0 +1,5 @@
+package com.study.springbootboard.domain.type;
+
+public enum SearchType {
+    TITLE, CONTENT, ID, NICKNAME, HASHTAG
+}

--- a/src/main/java/com/study/springbootboard/dto/ArticleCommentDto.java
+++ b/src/main/java/com/study/springbootboard/dto/ArticleCommentDto.java
@@ -1,0 +1,16 @@
+package com.study.springbootboard.dto;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+public record ArticleCommentDto(
+        LocalDateTime createdAt,
+        String createdBy,
+        LocalDateTime modifiedAt,
+        String modifiedBy,
+        String content
+) {
+    public static ArticleCommentDto of(LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy, String content) {
+        return new ArticleCommentDto(createdAt, createdBy, modifiedAt, modifiedBy, content);
+    }
+}

--- a/src/main/java/com/study/springbootboard/dto/ArticleDto.java
+++ b/src/main/java/com/study/springbootboard/dto/ArticleDto.java
@@ -1,0 +1,16 @@
+package com.study.springbootboard.dto;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+public record ArticleDto(
+        LocalDateTime createdAt,
+        String createdBy,
+        String title,
+        String content,
+        String hashtag
+) {
+    public static ArticleDto of(LocalDateTime createdAt, String createdBy, String title, String content, String hashtag) {
+        return new ArticleDto(createdAt, createdBy, title, content, hashtag);
+    }
+}

--- a/src/main/java/com/study/springbootboard/dto/ArticleUpdateDto.java
+++ b/src/main/java/com/study/springbootboard/dto/ArticleUpdateDto.java
@@ -1,0 +1,14 @@
+package com.study.springbootboard.dto;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+public record ArticleUpdateDto(
+        String title,
+        String content,
+        String hashtag
+) {
+    public static ArticleUpdateDto of(String title, String content, String hashtag) {
+        return new ArticleUpdateDto(title, content, hashtag);
+    }
+}

--- a/src/main/java/com/study/springbootboard/service/ArticleCommentService.java
+++ b/src/main/java/com/study/springbootboard/service/ArticleCommentService.java
@@ -1,0 +1,27 @@
+package com.study.springbootboard.service;
+
+import com.study.springbootboard.dto.ArticleCommentDto;
+import com.study.springbootboard.repository.ArticleCommentRepository;
+import com.study.springbootboard.repository.ArticleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class ArticleCommentService {
+
+    private final ArticleRepository articleRepository;
+    private final ArticleCommentRepository articleCommentRepository;
+
+    @Transactional(readOnly = true)
+    public List<ArticleCommentDto> searchArticleComment(long articleId) {
+        return List.of();
+    }
+
+    public void saveArticleComment(ArticleCommentDto of) {
+    }
+}

--- a/src/main/java/com/study/springbootboard/service/ArticleService.java
+++ b/src/main/java/com/study/springbootboard/service/ArticleService.java
@@ -1,0 +1,39 @@
+package com.study.springbootboard.service;
+
+import com.study.springbootboard.domain.type.SearchType;
+import com.study.springbootboard.dto.ArticleDto;
+import com.study.springbootboard.dto.ArticleUpdateDto;
+import com.study.springbootboard.repository.ArticleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class ArticleService {
+
+    private final ArticleRepository articleRepository;
+
+    @Transactional(readOnly = true)
+    public Page<ArticleDto> searchArticles(SearchType title, String search_keyword) {
+        return Page.empty();
+    }
+
+    @Transactional(readOnly = true)
+    public ArticleDto searchArticle(long l) {
+        return null;
+    }
+
+    public void saveArticle(ArticleDto dto) {
+    }
+
+    public void updateArticle(long articleId, ArticleUpdateDto dto) {
+    }
+
+    public void deleteArticle(long articleId) {
+    }
+}

--- a/src/test/java/com/study/springbootboard/controller/MainControllerTest.java
+++ b/src/test/java/com/study/springbootboard/controller/MainControllerTest.java
@@ -1,0 +1,32 @@
+package com.study.springbootboard.controller;
+
+import com.study.springbootboard.config.SecurityConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Import(SecurityConfig.class)
+@WebMvcTest(MainController.class)
+class MainControllerTest {
+
+    private final MockMvc mvc;
+
+    public MainControllerTest(@Autowired MockMvc mvc) {
+        this.mvc = mvc;
+    }
+
+    @Test
+    void givenNothing_whenRequestingRootPage_thenRedirectsToArticlesPage() throws Exception {
+        // Given
+
+        // When & Then
+        mvc.perform(get("/"))
+                .andExpect(status().is3xxRedirection());
+    }
+}

--- a/src/test/java/com/study/springbootboard/service/ArticleCommentServiceTest.java
+++ b/src/test/java/com/study/springbootboard/service/ArticleCommentServiceTest.java
@@ -1,0 +1,64 @@
+package com.study.springbootboard.service;
+
+import com.study.springbootboard.domain.Article;
+import com.study.springbootboard.domain.ArticleComment;
+import com.study.springbootboard.dto.ArticleCommentDto;
+import com.study.springbootboard.repository.ArticleCommentRepository;
+import com.study.springbootboard.repository.ArticleRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@DisplayName("비즈니스 로직 - 댓글")
+@ExtendWith(MockitoExtension.class)
+class ArticleCommentServiceTest {
+
+    @InjectMocks private ArticleCommentService sut;
+
+    @Mock private ArticleRepository articleRepository;
+    @Mock private ArticleCommentRepository articleCommentRepository;
+
+    @DisplayName("게시글 ID로 조회하면, 해당하는 댓글 리스트를 반환한다.")
+    @Test
+    void givenArticleId_whenSearchingComments_thenReturnsArticleComments() {
+        // Given
+        Long articleId = 1L;
+
+        given(articleRepository.findById(articleId)).willReturn(Optional.of(
+                Article.of(null, "title", "content", "#java"))
+        );
+
+        // When
+        List<ArticleCommentDto> articleComments = sut.searchArticleComment(1L);
+
+        // Then
+        assertThat(articleComments).isNotNull();
+        then(articleRepository).should().findById(articleId);
+    }
+
+    @DisplayName("댓글 정보를 입력하면, 댓글을 저장한다.")
+    @Test
+    void givenArticleCommentInfo_whenSavingArticleComment_thenSavesArticleComment() {
+        // Given
+        given(articleCommentRepository.save(any(ArticleComment.class))).willReturn(null);
+
+        // When
+        sut.saveArticleComment(ArticleCommentDto.of(LocalDateTime.now(), "nana", LocalDateTime.now(), "nana", "comment"));
+
+        // Then
+        then(articleCommentRepository).should().save(any(ArticleComment.class));
+    }
+
+}

--- a/src/test/java/com/study/springbootboard/service/ArticleServiceTest.java
+++ b/src/test/java/com/study/springbootboard/service/ArticleServiceTest.java
@@ -1,0 +1,94 @@
+package com.study.springbootboard.service;
+
+import com.study.springbootboard.domain.Article;
+import com.study.springbootboard.domain.type.SearchType;
+import com.study.springbootboard.dto.ArticleDto;
+import com.study.springbootboard.dto.ArticleUpdateDto;
+import com.study.springbootboard.repository.ArticleRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.*;
+
+@DisplayName("비즈니스 로직 - 게시글")
+@ExtendWith(MockitoExtension.class)
+class ArticleServiceTest {
+
+    @InjectMocks private ArticleService sut; // 테스트 대상(네이밍)
+    @Mock private ArticleRepository articleRepository;
+
+    @DisplayName("게시글을 검색하면, 게시글 페이지를 반환한다.")
+    @Test
+    void givenNoSearchParameters_whenSearchingArticles_thenReturnsArticlePage() {
+        // Given
+
+        // When
+        Page<ArticleDto> articles = sut.searchArticles(SearchType.TITLE, "search keyword");
+
+        // Then
+        assertThat(articles).isNotNull();
+    }
+
+    @DisplayName("게시글을 조회하면, 게시글 페이지를 반환한다.")
+    @Test
+    void givenArticleId_whenSearchingArticles_thenReturnsArticle() {
+        // Given
+
+        // When
+        ArticleDto articles = sut.searchArticle(1L);
+
+        // Then
+        assertThat(articles).isNotNull();
+    }
+
+    @DisplayName("게시글 정보를 입력하면, 게시글을 생성한다")
+    @Test
+    void givenArticleInfo_whenSavingArticle_thenSavesArticle() {
+        // Given
+        given(articleRepository.save(any(Article.class))).willReturn(null);
+
+        // When
+        sut.saveArticle(ArticleDto.of(LocalDateTime.now(), "nana", "title", "content", "#java"));
+
+        // Then
+        then(articleRepository).should().save(any(Article.class));
+    }
+
+    @DisplayName("게시글의 ID와 수정 정보 입력하면, 게시글을 수정한다")
+    @Test
+    void givenArticleIdAndModifiedInfo_whenUpdatingArticle_thenUpdatesArticle() {
+        // Given
+        given(articleRepository.save(any(Article.class))).willReturn(null);
+
+        // When
+        sut.updateArticle(1L, ArticleUpdateDto.of("title", "content", "#java"));
+
+        // Then
+        then(articleRepository).should().save(any(Article.class));
+    }
+
+    @DisplayName("게시글의 ID를 입력하면, 게시글을 삭제한다")
+    @Test
+    void givenArticleId_whenDeletingArticle_thenDeletesArticle() {
+        // Given
+        willDoNothing().given(articleRepository).delete(any(Article.class));
+
+        // When
+        sut.deleteArticle(1L);
+
+        // Then
+        then(articleRepository).should().delete(any(Article.class));
+    }
+
+
+}


### PR DESCRIPTION
테이블 필드 수정으로 영향 받은
`data.sql` 테스트 데이터도 모두 업데이트

하는 김에 게시글 -> 댓글 컬렉션의 정렬을 최신 순으로 적용