### PR TITLE
DTO 들에 Serializable 인터페이스 제거

### DIFF
--- a/src/main/java/com/study/springbootboard/dto/ArticleCommentDto.java
+++ b/src/main/java/com/study/springbootboard/dto/ArticleCommentDto.java
@@ -17,6 +17,7 @@ public record ArticleCommentDto(
         LocalDateTime modifiedAt,
         String modifiedBy
 ) {
+
     public static ArticleCommentDto of(Long articleId, UserAccountDto userAccountDto, String content) {
         return new ArticleCommentDto(null, articleId, userAccountDto, content, null, null, null, null);
     }
@@ -37,11 +38,12 @@ public record ArticleCommentDto(
         );
     }
 
-    public ArticleComment toEntity(Article article, UserAccount userAccount) {
+    public ArticleComment toEntity(Article entity) {
         return ArticleComment.of(
-                article,
-                userAccount,
+                entity,
+                userAccountDto.toEntity(),
                 content
         );
     }
+
 }

--- a/src/main/java/com/study/springbootboard/dto/response/ArticleCommentResponse.java
+++ b/src/main/java/com/study/springbootboard/dto/response/ArticleCommentResponse.java
@@ -2,7 +2,6 @@ package com.study.springbootboard.dto.response;
 
 import com.study.springbootboard.dto.ArticleCommentDto;
 
-import java.io.Serializable;
 import java.time.LocalDateTime;
 
 public record ArticleCommentResponse(
@@ -12,7 +11,7 @@ public record ArticleCommentResponse(
         String email,
         String nickname,
         String userId
-) implements Serializable {
+) {
 
     public static ArticleCommentResponse of(Long id, String content, LocalDateTime createdAt, String email, String nickname, String userId) {
         return new ArticleCommentResponse(id, content, createdAt, email, nickname, userId);

--- a/src/main/java/com/study/springbootboard/dto/response/ArticleResponse.java
+++ b/src/main/java/com/study/springbootboard/dto/response/ArticleResponse.java
@@ -2,7 +2,6 @@ package com.study.springbootboard.dto.response;
 
 import com.study.springbootboard.dto.ArticleDto;
 
-import java.io.Serializable;
 import java.time.LocalDateTime;
 
 public record ArticleResponse(
@@ -13,7 +12,7 @@ public record ArticleResponse(
         LocalDateTime createdAt,
         String email,
         String nickname
-) implements Serializable {
+) {
 
     public static ArticleResponse of(Long id, String title, String content, String hashtag, LocalDateTime createdAt, String email, String nickname) {
         return new ArticleResponse(id, title, content, hashtag, createdAt, email, nickname);


### PR DESCRIPTION
JPA Buddy 를 이용해 작성한 DTO들인데,
자동으로 `implements Serializable` 이 들어가버림
이 프로젝트는 직렬화로 Jackson을 사용하므로 필요하지 않고, 
의도하여 넣은 코드도 아님. 그러므로 삭제