### PR TITLE
헤로쿠에 배포하기 (ClearDB -> JawsDB)

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -32,7 +32,8 @@ spring:
 spring:
   config.activate.on-profile: heroku
   datasource:
-    url: ${CLEARDB_DATABASE_URL}
+    url: ${JAWSDB_URL}
+    driver-class-name: com.mysql.cj.jdbc.Driver
   jpa.hibernate.ddl-auto: create
   sql.init.mode: always
 


### PR DESCRIPTION
조사해본 결과, cleardb의 기본 mysql 버전이 `5.6`으로 너무 낮기 때문에 문제가 발생한 것으로 확인함 (`5.6` 버전에서는 `article_comment.content` 인덱스 사이즈가 너무 큼)
대안으로 jawsdb 를 찾아냄. 기본 mysql 버전 `8.0`
이를 이용해 환경변수를 다시 작업함

This fixes #53 

* https://devcenter.heroku.com/articles/jawsdb#provisioning-with-custom-options
* https://devcenter.heroku.com/articles/cleardb#the-cleardb-dedicated-mysql-complete-tutorial-local-setup